### PR TITLE
Update conftest.py to ignore pip installed files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ tests/parser.out
 tests/parsetab.py
 .coverage
 .DS_Store
+# pip directory for -e in requirements.txt
+src

--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,8 @@ import pytest
 from magma.circuit import magma_clear_circuit_cache
 from magma import clear_cachedFunctions
 
+collect_ignore = ["src"]  # pip folder that contains dependencies like magma
+
 
 @pytest.fixture(autouse=True)
 def magma_test():


### PR DESCRIPTION
When we do `pip install -r requirements.txt`, it creates a directory `src` that contains the source files downloaded from magma/mantle (this because we haven't released them on PYPI yet, so pip has to fetch from the repositories directly).

This creates an issue where `pytest` will discover the tests inside magma/mantle and try to run them, so we just add them to the collect_ignore variable in `conftest.py`. Also ignores `src` in `.gitignore` so it isn't accidentally checked into git.