### PR TITLE
Compile using a fresh temporary directory to avoid conflicts on shared machines

### DIFF
--- a/common/util.py
+++ b/common/util.py
@@ -1,5 +1,6 @@
 import os
 import magma as m
+import tempfile
 
 
 def compile_to_verilog(module, name, outpath, use_coreir=True):
@@ -10,10 +11,11 @@ def compile_to_verilog(module, name, outpath, use_coreir=True):
     """
     verilog_file = f"{outpath}/{name}.v"
     if use_coreir:
-        m.compile(f"/tmp/{name}", module, output="coreir")
-        json_file = f"/tmp/{name}.json"
-        res = os.system(f"coreir -i {json_file} -o {verilog_file}")
-        return res == 0
+        with tempfile.TemporaryDirectory() as temp_dir:
+            m.compile(os.path.join(temp_dir, name), module, output="coreir")
+            json_file = os.path.join(temp_dir, f"{name}.json")
+            res = os.system(f"coreir -i {json_file} -o {verilog_file}")
+            return res == 0
     print("Warning: compiling magma straight to verilog will not import "
           "CoreIR modules")
     m.compile(f"{verilog_file}", module, output="verilog")


### PR DESCRIPTION
Addresses issue in https://github.com/rsetaluri/magma_cgra/issues/22#issuecomment-405343353

Basically, on a shared machine environment we run into an issue where if the file was created by another user, we can't edit it. This uses python's `tempfile` library to create a new, unique temporary directory for the temporary file.