### PR TITLE
Skip test if irun not available

### DIFF
--- a/common/util.py
+++ b/common/util.py
@@ -1,6 +1,8 @@
 import os
 import magma as m
 import tempfile
+import pytest
+import shutil
 
 
 def compile_to_verilog(module, name, outpath, use_coreir=True):
@@ -20,3 +22,10 @@ def compile_to_verilog(module, name, outpath, use_coreir=True):
           "CoreIR modules")
     m.compile(f"{verilog_file}", module, output="verilog")
     return True
+
+
+def skip_unless_irun_available(fn):
+    return pytest.mark.skipif(
+        shutil.which("irun") is None,
+        reason="irun (simulator command) not available"
+    )(fn)

--- a/test_cb/test_regression_ncsim.py
+++ b/test_cb/test_regression_ncsim.py
@@ -3,6 +3,7 @@ from cb.cb_magma import define_cb
 from common.genesis_wrapper import run_genesis
 from common.util import compile_to_verilog, skip_unless_irun_available
 
+
 def run_ncsim_regression(params):
     # Magma version.
     magma_cb = define_cb(**params)

--- a/test_cb/test_regression_ncsim.py
+++ b/test_cb/test_regression_ncsim.py
@@ -1,13 +1,11 @@
 import os
-import magma as m
 from cb.cb_magma import define_cb
 from common.genesis_wrapper import run_genesis
 from common.util import compile_to_verilog
 import pytest
+import shutil
 
 
-@pytest.mark.skipif(os.environ.get("TRAVIS") == "true",
-                    reason="ncsim not available on travis")
 def run_ncsim_regression(params):
     # Magma version.
     magma_cb = define_cb(**params)
@@ -31,8 +29,8 @@ def run_ncsim_regression(params):
     assert res == 0
 
 
-@pytest.mark.skipif(os.environ.get("TRAVIS") == "true",
-                    reason="ncsim not available on travis")
+@pytest.mark.skipif(shutil.which("irun") is None,
+                    "irun (simulator command) not available")
 def test_16_10_111110111_1_7():
     params = {
         "width": 16,
@@ -44,8 +42,8 @@ def test_16_10_111110111_1_7():
     run_ncsim_regression(params)
 
 
-@pytest.mark.skipif(os.environ.get("TRAVIS") == "true",
-                    reason="ncsim not available on travis")
+@pytest.mark.skipif(shutil.which("irun") is None,
+                    "irun (simulator command) not available")
 def test_7_8_11111111_0_0():
     params = {
         "width": 7,

--- a/test_cb/test_regression_ncsim.py
+++ b/test_cb/test_regression_ncsim.py
@@ -1,10 +1,7 @@
 import os
 from cb.cb_magma import define_cb
 from common.genesis_wrapper import run_genesis
-from common.util import compile_to_verilog
-import pytest
-import shutil
-
+from common.util import compile_to_verilog, skip_unless_irun_available
 
 def run_ncsim_regression(params):
     # Magma version.
@@ -29,8 +26,7 @@ def run_ncsim_regression(params):
     assert res == 0
 
 
-@pytest.mark.skipif(shutil.which("irun") is None,
-                    reason="irun (simulator command) not available")
+@skip_unless_irun_available
 def test_16_10_111110111_1_7():
     params = {
         "width": 16,
@@ -42,8 +38,7 @@ def test_16_10_111110111_1_7():
     run_ncsim_regression(params)
 
 
-@pytest.mark.skipif(shutil.which("irun") is None,
-                    reason="irun (simulator command) not available")
+@skip_unless_irun_available
 def test_7_8_11111111_0_0():
     params = {
         "width": 7,

--- a/test_cb/test_regression_ncsim.py
+++ b/test_cb/test_regression_ncsim.py
@@ -30,7 +30,7 @@ def run_ncsim_regression(params):
 
 
 @pytest.mark.skipif(shutil.which("irun") is None,
-                    "irun (simulator command) not available")
+                    reason="irun (simulator command) not available")
 def test_16_10_111110111_1_7():
     params = {
         "width": 16,
@@ -43,7 +43,7 @@ def test_16_10_111110111_1_7():
 
 
 @pytest.mark.skipif(shutil.which("irun") is None,
-                    "irun (simulator command) not available")
+                    reason="irun (simulator command) not available")
 def test_7_8_11111111_0_0():
     params = {
         "width": 7,


### PR DESCRIPTION
This prevents the tests from failing when testing on a local machine where ncsim isn't available. Ideally we can remove this once we get the `iverilog` version of the test (since we can expect this to be installable in broader contexts).