### PR TITLE
Add base classes for functional models

### DIFF
--- a/common/configurable_model.py
+++ b/common/configurable_model.py
@@ -1,0 +1,38 @@
+from bit_vector import BitVector
+from common.model import Model
+
+
+def ConfigurableModel(config_data_width, config_addr_width):
+    """
+    This function returns a class (parameterized by @config_data_width and
+    @config_addr_width) which can be used as the base class for any functional
+    model implementing a configurable module. For example if we have
+    configurable module Foo:
+
+        class Foo(ConfigurableModel(32, 32)):
+            ...
+
+    In our test code we can then do:
+
+        foo = Foo(...)
+        foo.configure(addr, data)
+        assert foo.read_config(addr) == data
+
+    Or internally in Foo, do:
+
+        conf = self.__config[addr]
+
+    """
+    class _ConfigurableModel(Model):
+        def __init__(self):
+            self.__config = {}
+
+        def configure(self, addr: BitVector, data: BitVector):
+            assert data.num_bits == config_data_width
+            assert addr.num_bits == config_addr_width
+            self.__config[addr.unsigned_value] = data
+
+        def read_config(self, addr):
+            return self.__config[addr.unsigned_value]
+
+    return _ConfigurableModel

--- a/common/configurable_model.py
+++ b/common/configurable_model.py
@@ -20,19 +20,19 @@ def ConfigurableModel(config_data_width, config_addr_width):
 
     Or internally in Foo, do:
 
-        conf = self.__config[addr]
+        conf = self._config[addr]
 
     """
     class _ConfigurableModel(Model):
         def __init__(self):
-            self.__config = {}
+            self._config = {}
 
         def configure(self, addr: BitVector, data: BitVector):
             assert data.num_bits == config_data_width
             assert addr.num_bits == config_addr_width
-            self.__config[addr.unsigned_value] = data
+            self._config[addr.unsigned_value] = data
 
         def read_config(self, addr):
-            return self.__config[addr.unsigned_value]
+            return self._config[addr.unsigned_value]
 
     return _ConfigurableModel

--- a/common/model.py
+++ b/common/model.py
@@ -1,13 +1,13 @@
 from abc import ABC, abstractmethod
 
 
-"""
-This is the interface/abstract base class which should be used by all classes
-implementing a functional model. It is very bare-bones, but requires that
-subclasses implement a __call__ function, which should be the main mechanism of
-evaluating the functional model.
-"""
 class Model(ABC):
+    """
+    This is the interface/abstract base class which should be used by all
+    classes implementing a functional model. It is very bare-bones, but requires
+    that subclasses implement a __call__ function, which should be the main
+    mechanism of evaluating the functional model.
+    """
     @abstractmethod
     def __init__(self):
         pass

--- a/common/model.py
+++ b/common/model.py
@@ -1,0 +1,21 @@
+from abc import ABC, abstractmethod
+
+
+"""
+This is the interface/abstract base class which should be used by all classes
+implementing a functional model. It is very bare-bones, but requires that
+subclasses implement a __call__ function, which should be the main mechanism of
+evaluating the functional model.
+"""
+class Model(ABC):
+    @abstractmethod
+    def __init__(self):
+        pass
+
+    """
+    Returns the output of the functional model (in whatever form is
+    appropriate). All subclasses should implement this function.
+    """
+    @abstractmethod
+    def __call__(self, *args):
+        pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pytest]
+pep8maxlinelength = 80

--- a/test_common/test_configurable_model.py
+++ b/test_common/test_configurable_model.py
@@ -1,0 +1,33 @@
+import random
+from bit_vector import BitVector
+from common.configurable_model import ConfigurableModel
+
+
+def test_configurable_model_smoke():
+    EXPECTED_MSG = "TypeError(\"Can't instantiate abstract class _ConfigurableModel with abstract methods __call__\",)" # nopep8
+    has_type_error = False
+    try:
+        my_model = ConfigurableModel(32, 32)()
+    except TypeError as e:
+        msg = e.__repr__()        
+        has_type_error = True
+    assert has_type_error
+    assert msg == EXPECTED_MSG
+
+
+def test_configurable_model_subclass():
+    def value(v):
+        return BitVector(v, 32)
+    class Foo(ConfigurableModel(32, 32)):
+        def __init__(self):
+            super().__init__()
+
+        def __call__(self):
+            return 0
+
+    f = Foo()
+    addr = value(random.randint(0, 2**32 - 1))
+    data = value(random.randint(0, 2**32 - 1))
+    f.configure(addr, data)
+    assert f.read_config(addr) == data
+    assert f() == 0

--- a/test_common/test_configurable_model.py
+++ b/test_common/test_configurable_model.py
@@ -4,12 +4,12 @@ from common.configurable_model import ConfigurableModel
 
 
 def test_configurable_model_smoke():
-    EXPECTED_MSG = "TypeError(\"Can't instantiate abstract class _ConfigurableModel with abstract methods __call__\",)" # nopep8
+    EXPECTED_MSG = "TypeError(\"Can't instantiate abstract class _ConfigurableModel with abstract methods __call__\",)"  # nopep8
     has_type_error = False
     try:
         my_model = ConfigurableModel(32, 32)()
     except TypeError as e:
-        msg = e.__repr__()        
+        msg = e.__repr__()
         has_type_error = True
     assert has_type_error
     assert msg == EXPECTED_MSG
@@ -18,6 +18,7 @@ def test_configurable_model_smoke():
 def test_configurable_model_subclass():
     def value(v):
         return BitVector(v, 32)
+
     class Foo(ConfigurableModel(32, 32)):
         def __init__(self):
             super().__init__()

--- a/test_common/test_model.py
+++ b/test_common/test_model.py
@@ -2,12 +2,12 @@ from common.model import Model
 
 
 def test_model():
-    EXPECTED_MSG = "TypeError(\"Can't instantiate abstract class Model with abstract methods __call__, __init__\",)" # nopep8
+    EXPECTED_MSG = "TypeError(\"Can't instantiate abstract class Model with abstract methods __call__, __init__\",)"  # nopep8
     has_type_error = False
     try:
         my_model = Model()
     except TypeError as e:
-        msg = e.__repr__()        
+        msg = e.__repr__()
         has_type_error = True
     assert has_type_error
     assert msg == EXPECTED_MSG

--- a/test_common/test_model.py
+++ b/test_common/test_model.py
@@ -1,0 +1,13 @@
+from common.model import Model
+
+
+def test_model():
+    EXPECTED_MSG = "TypeError(\"Can't instantiate abstract class Model with abstract methods __call__, __init__\",)" # nopep8
+    has_type_error = False
+    try:
+        my_model = Model()
+    except TypeError as e:
+        msg = e.__repr__()        
+        has_type_error = True
+    assert has_type_error
+    assert msg == EXPECTED_MSG


### PR DESCRIPTION
Added an abstract base class Model, and a subclass ConfigurableModel,
which can be used to create classes for functional models. I suggest
that every (non stateful) functional model have ConfigurableModel as an
ancestor, and similarly all fn models for configurable modules have
ConfigurableModel as an ancestor.

Also added basic tests.