### PR TITLE
Install latest coreir version now that master is fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,9 @@ python:
 
 install:
     # Convenience script for installing coreir on travis
-    # - wget https://raw.githubusercontent.com/phanrahan/magma/master/.travis/install_coreir.sh
-    # - source install_coreir.sh
-    - wget https://github.com/rdaly525/coreir/releases/download/v0.0.12/coreir.tar.gz
-    - mkdir coreir_release;
-    - tar -xf coreir.tar.gz -C coreir_release --strip-components 1;
-    - export PATH=$TRAVIS_BUILD_DIR/coreir_release/bin:$PATH;
-    - export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/coreir_release/lib:$LD_LIBRARY_PATH;
+    - wget https://raw.githubusercontent.com/phanrahan/magma/master/.travis/install_coreir.sh
+    - source install_coreir.sh
+
     - pip install -r requirements.txt
     - pip install python-coveralls
     - pip install pytest-cov pytest-pep8

--- a/README.md
+++ b/README.md
@@ -7,15 +7,10 @@ The main purpose of this repo is to investigate and experiment with implementing
 If you're using the Kiwi machine, see [this wiki page](https://github.com/rsetaluri/magma_cgra/wiki/Kiwi-Environment) for info on getting your python environment setup. If you use the shared Python environment, you do not need to run the pip install command.
 
 ## Install CoreIR
-
-Note that we install an old version of CoreIR (version `v0.0.12`). See issue #27 for more details.
-
 ```
-wget https://github.com/rdaly525/coreir/releases/download/v0.0.12/coreir.tar.gz
-mkdir coreir_release
-tar -xf coreir.tar.gz -C coreir_release --strip-components 1;
-cd coreir_release
-make install  # run with sudo on linux
+git clone https://github.com/rdaly525/coreir.git
+cd coreir
+make install -j  # Use sudo on linux
 ```
 
 ## Install python dependencies


### PR DESCRIPTION
@alexcarsello @ankita0805 after this is merged, you can drop the `export` commands that use an old version of coreir. We can update the shared kiwi installation to be the latest master.