### PR TITLE
Update cb/simple_cb for upstream mantle changes

### DIFF
--- a/cb/cb_magma.py
+++ b/cb/cb_magma.py
@@ -118,7 +118,7 @@ def define_cb(width, num_tracks, has_constant, default_value,
         # match the genesis verilog for regression testing, this should really
         # use m.ClockInterface
         IO = ["clk", m.In(m.Clock),
-              "reset", m.In(m.Reset)]
+              "reset", m.In(m.AsyncReset)]
 
         IO += generate_inputs(num_tracks, feedthrough_outputs, width)
 
@@ -140,12 +140,11 @@ def define_cb(width, num_tracks, has_constant, default_value,
             config_cb = mantle.Register(config_reg_width,
                                         init=config_reg_reset_bit_vector,
                                         has_ce=True,
-                                        has_reset=True)
+                                        has_async_reset=True)
 
             config_addr_zero = mantle.eq(m.uint(0, 8), io.config_addr[24:32])
 
-            config_cb(io.config_data, reset=io.reset,
-                      CE=io.config_en & config_addr_zero)
+            config_cb(io.config_data, CE=io.config_en & config_addr_zero)
 
             # if the top 8 bits of config_addr are 0, then read_data is equal
             # to the value of the config register, otherwise it is 0

--- a/simple_cb/simple_cb_magma.py
+++ b/simple_cb/simple_cb_magma.py
@@ -47,18 +47,17 @@ def define_simple_cb(width, num_tracks):
             "config_en", m.In(m.Bit),
             "read_data", m.Out(m.Bits(CONFIG_DATA_WIDTH))
         ]
-        IO += m.ClockInterface(has_reset=True)
+        IO += m.ClockInterface(has_async_reset=True)
 
         @classmethod
         def definition(io):
             config = mantle.Register(CONFIG_DATA_WIDTH,
                                      init=config_reset,
                                      has_ce=True,
-                                     has_reset=True)
+                                     has_async_reset=True)
 
             config_addr_zero = mantle.eq(m.uint(0, 8), io.config_addr[24:32])
-            config(io.config_data, reset=io.RESET,
-                   CE=(io.config_en & config_addr_zero))
+            config(io.config_data, CE=(io.config_en & config_addr_zero))
 
             # If the top 8 bits of config_addr are 0, then read_data is equal
             # to the value of the config register, otherwise it is 0.

--- a/test_common/gold/config_register.json
+++ b/test_common/gold/config_register.json
@@ -44,7 +44,7 @@
           ["self.addr","inst1.I0"]
         ]
       },
-      "DFF_init0_has_ceTrue_has_resetTrue":{
+      "DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse":{
         "type":["Record",[
           ["I","BitIn"],
           ["O","Bit"],
@@ -53,27 +53,31 @@
           ["RESET","BitIn"]
         ]],
         "instances":{
+          "bit_const_GND":{
+            "modref":"corebit.const",
+            "modargs":{"value":["Bool",false]}
+          },
           "inst0":{
-            "genref":"coreir.reg_arst",
+            "genref":"coreir.reg",
             "genargs":{"width":["Int",1]},
-            "modargs":{"arst_posedge":["Bool",true], "clk_posedge":["Bool",true], "init":[["BitVector",1],"1'h0"]}
+            "modargs":{"clk_posedge":["Bool",true], "init":[["BitVector",1],"1'h0"]}
           },
           "inst1":{
-            "genref":"coreir.wrap",
-            "genargs":{"type":["CoreIRType",["Named","coreir.arst"]]}
+            "modref":"global._Mux2"
           },
           "inst2":{
             "modref":"global._Mux2"
           }
         },
         "connections":[
-          ["inst1.out","inst0.arst"],
+          ["inst1.I.1","bit_const_GND.out"],
           ["self.CLK","inst0.clk"],
           ["inst2.O","inst0.in.0"],
           ["inst2.I.0","inst0.out.0"],
           ["self.O","inst0.out.0"],
-          ["self.RESET","inst1.in"],
-          ["self.I","inst2.I.1"],
+          ["self.I","inst1.I.0"],
+          ["inst2.I.1","inst1.O"],
+          ["self.RESET","inst1.S"],
           ["self.CE","inst2.S"]
         ]
       },
@@ -105,100 +109,100 @@
         ]],
         "instances":{
           "inst0":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst1":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst10":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst11":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst12":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst13":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst14":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst15":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst16":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst17":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst18":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst19":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst2":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst20":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst21":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst22":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst23":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst24":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst25":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst26":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst27":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst28":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst29":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst3":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst30":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst31":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst4":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst5":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst6":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst7":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst8":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           },
           "inst9":{
-            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue"
+            "modref":"global.DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse"
           }
         },
         "connections":[

--- a/test_common/test_config_register.py
+++ b/test_common/test_config_register.py
@@ -17,8 +17,8 @@ def test_config_register():
     gold_check = filecmp.cmp("config_register.json",
                              "test_common/gold/config_register.json")
     assert gold_check
-    res = os.system("\\rm config_register.json")
     assert res == 0
+    res = os.system("\\rm config_register.json")
 
     # Check the module against a simple simulation.
     simulator = PythonSimulator(cr, clock=cr.CLK)

--- a/test_common/test_config_register.py
+++ b/test_common/test_config_register.py
@@ -17,8 +17,8 @@ def test_config_register():
     gold_check = filecmp.cmp("config_register.json",
                              "test_common/gold/config_register.json")
     assert gold_check
-    assert res == 0
     res = os.system("\\rm config_register.json")
+    assert res == 0
 
     # Check the module against a simple simulation.
     simulator = PythonSimulator(cr, clock=cr.CLK)


### PR DESCRIPTION
There's now a distinct interface for synchronous and asynchronous resets.

I removed the explicit `reset=...` because the reset signal is automatically wired in the backend, so you don't need to specify it unless you want something different than the default behavior.