### PR TITLE
Use eq operator

### DIFF
--- a/cb/cb_magma.py
+++ b/cb/cb_magma.py
@@ -142,7 +142,7 @@ def define_cb(width, num_tracks, has_constant, default_value,
                                         has_ce=True,
                                         has_async_reset=True)
 
-            config_addr_zero = mantle.eq(m.uint(0, 8), io.config_addr[24:32])
+            config_addr_zero = m.bits(0, 8) == io.config_addr[24:32]
 
             config_cb(io.config_data, CE=io.config_en & config_addr_zero)
 

--- a/simple_cb/simple_cb_magma.py
+++ b/simple_cb/simple_cb_magma.py
@@ -56,7 +56,7 @@ def define_simple_cb(width, num_tracks):
                                      has_ce=True,
                                      has_async_reset=True)
 
-            config_addr_zero = mantle.eq(m.uint(0, 8), io.config_addr[24:32])
+            config_addr_zero = m.bits(0, 8) == io.config_addr[24:32]
             config(io.config_data, CE=(io.config_en & config_addr_zero))
 
             # If the top 8 bits of config_addr are 0, then read_data is equal


### PR DESCRIPTION
`==` is now overloaded! Also changed it from `uint` to `bits` since that's the type of the config_addr. This doesn't matter since they're sub types (I checked by running the tests with `m.bits` and `m.uint`), but it's a bit more explicit when reading the code.