### PR TITLE
Fix coverage invocation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,20 @@ install:
     - wget https://raw.githubusercontent.com/python/cpython/master/Lib/filecmp.py
 
 script:
-    - pytest --cov  cb common global_controller mem pe sb simple_cb
-             --pep8 cb common global_controller mem pe sb simple_cb
+    - pytest --cov cb
+             --pep8 cb
+             --cov common
+             --pep8 common
+             --cov global_controller
+             --pep8 global_controller
+             --cov mem
+             --pep8 mem
+             --cov pe
+             --pep8 pe
+             --cov sb
+             --pep8 sb
+             --cov simple_cb
+             --pep8 simple_cb
              --ignore=filecmp.py
              --ignore=Genesis2/
              -v --cov-report term-missing .

--- a/common/irun.py
+++ b/common/irun.py
@@ -4,6 +4,8 @@ import os
 TCL_FILE = "common/irun/cmd.tcl"
 
 
+# We don't cover this function because irun is not available on travis
+# pragma: nocover
 def irun(input_files,
          top_name="top",
          tcl_file=TCL_FILE,

--- a/common/util.py
+++ b/common/util.py
@@ -1,27 +1,5 @@
-import os
-import magma as m
-import tempfile
 import pytest
 import shutil
-
-
-def compile_to_verilog(module, name, outpath, use_coreir=True):
-    """
-    Note(rsetaluri): Be wary calling this function! Multiple invocations of
-    this function in the same runtime may not work due to a caching bug in
-    magma.
-    """
-    verilog_file = f"{outpath}/{name}.v"
-    if use_coreir:
-        with tempfile.TemporaryDirectory() as temp_dir:
-            m.compile(os.path.join(temp_dir, name), module, output="coreir")
-            json_file = os.path.join(temp_dir, f"{name}.json")
-            res = os.system(f"coreir -i {json_file} -o {verilog_file}")
-            return res == 0
-    print("Warning: compiling magma straight to verilog will not import "
-          "CoreIR modules")
-    m.compile(f"{verilog_file}", module, output="verilog")
-    return True
 
 
 def skip_unless_irun_available(fn):

--- a/conftest.py
+++ b/conftest.py
@@ -3,7 +3,10 @@ from magma.circuit import magma_clear_circuit_cache
 from magma import clear_cachedFunctions
 import magma.backend.coreir_ as coreir_
 
-collect_ignore = ["src"]  # pip folder that contains dependencies like magma
+collect_ignore = [
+    "src",  # pip folder that contains dependencies like magma
+    "parsetab.py"
+]
 
 
 @pytest.fixture(autouse=True)

--- a/test_cb/test_cb_regression.py
+++ b/test_cb/test_cb_regression.py
@@ -11,7 +11,6 @@ from cb.cb_genesis2 import define_cb_wrapper
 import magma as m
 import fault
 from magma.testing.verilator import compile, run_verilator_test
-from common.util import compile_to_verilog
 
 import pytest
 
@@ -44,7 +43,8 @@ def test_regression(default_value, num_tracks, has_constant):
     }
 
     magma_cb = define_cb(**params)
-    compile_to_verilog(magma_cb, magma_cb.name, "test_cb/build/")
+    m.compile(f"test_cb/build/{magma_cb.name}", magma_cb,
+              output="coreir-verilog")
 
     genesis_cb = define_cb_wrapper(**params, input_files=["cb/genesis/cb.vp"])
     genesis_verilog = "genesis_verif/cb.v"

--- a/test_cb/test_cb_regression_ncsim.py
+++ b/test_cb/test_cb_regression_ncsim.py
@@ -1,15 +1,14 @@
-import os
+import magma as m
 from cb.cb_magma import define_cb
 from common.genesis_wrapper import run_genesis
-from common.util import compile_to_verilog, skip_unless_irun_available
+from common.util import skip_unless_irun_available
 from common.irun import irun
 
 
 def run_ncsim_regression(params):
     # Magma version.
     magma_cb = define_cb(**params)
-    res = compile_to_verilog(magma_cb, magma_cb.name, "./")
-    assert res
+    m.compile(f"./{magma_cb.name}", magma_cb, output="coreir-verilog")
 
     # Genesis version.
     genesis_outfile = run_genesis("cb", "cb/genesis/cb.vp", params)

--- a/test_common/test_config_register.py
+++ b/test_common/test_config_register.py
@@ -40,3 +40,17 @@ def test_config_register():
     for (I, addr, out_expected) in sequence:
         out = step(BitVector(I, WIDTH), BitVector(addr, ADDR_WIDTH))
         assert out == BitVector(out_expected, WIDTH)
+
+
+def test_error():
+    try:
+        define_config_register(32, m.bits(4, 8), True, None)
+        assert False, "Should throw a ValueError"
+    except ValueError as e:
+        assert str(e) == "Argument _type must be Bits, UInt, or SInt"
+    try:
+        define_config_register(32, None, True)
+        assert False, "Should throw a ValueError"
+    except ValueError as e:
+        assert str(e) == ("Argument address must be instance of "
+                          "Bits, UInt, or SInt")

--- a/test_simple_cb/test_simple_cb_regression.py
+++ b/test_simple_cb/test_simple_cb_regression.py
@@ -11,7 +11,6 @@ from simple_cb.simple_cb_genesis2 import define_simple_cb_wrapper
 import magma as m
 import fault
 from magma.testing.verilator import compile, run_verilator_test
-from common.util import compile_to_verilog
 
 import pytest
 
@@ -50,9 +49,8 @@ def test_regression(num_tracks):
 
     # Create magma circuit.
     magma_simple_cb = define_simple_cb(**params)
-    res = compile_to_verilog(
-        magma_simple_cb, magma_simple_cb.name, "test_simple_cb/build/")
-    assert res
+    m.compile(f"test_simple_cb/build/{magma_simple_cb.name}", magma_simple_cb,
+              output="coreir-verilog")
 
     # Create genesis circuit.
     genesis_simple_cb = define_simple_cb_wrapper(


### PR DESCRIPTION
After inspecting the coverage report at coveralls, it seems like it was only reporting for the `cb` module.

I've updated the check to report for all of them by fixing the invocation of `pytest` on the travis script.

Not sure how this will affect our coverage report (might go down), but this would be good motivation to fix any missing coverage problems.