### PR TITLE
Fault compile and run

### DIFF
--- a/common/irun.py
+++ b/common/irun.py
@@ -5,11 +5,10 @@ TCL_FILE = "common/irun/cmd.tcl"
 
 
 # We don't cover this function because irun is not available on travis
-# pragma: nocover
 def irun(input_files,
          top_name="top",
          tcl_file=TCL_FILE,
-         cleanup=True):
+         cleanup=True):  # pragma: nocover
     if len(input_files) == 0:
         print("Warning: irun requires at least 1 input file. Skipping irun.")
         return True

--- a/test_cb/test_cb_regression.py
+++ b/test_cb/test_cb_regression.py
@@ -115,5 +115,5 @@ def test_regression(default_value, num_tracks, has_constant):
 
     for cb in [genesis_cb, magma_cb]:
         tester.circuit = cb
-        tester.compile_and_run("test_cb/build", target="verilator",
+        tester.compile_and_run(directory="test_cb/build", target="verilator",
                                flags=["-Wno-fatal"])

--- a/test_cb/test_cb_regression.py
+++ b/test_cb/test_cb_regression.py
@@ -69,8 +69,6 @@ def test_regression(default_value, num_tracks, has_constant):
     assert (inputs, data_width) == get_inputs_and_data_width(magma_cb), \
         "Inputs should be the same"
 
-    testvectors = []
-
     # TODO: Do we need this extra instantiation, could the function do it for
     # us?
     cb_functional_model = gen_cb(**params)()
@@ -114,9 +112,8 @@ def test_regression(default_value, num_tracks, has_constant):
                 tester.poke(getattr(genesis_cb, f"in_{i}"), inputs[i])
         tester.expect(genesis_cb.out, cb_functional_model(*_inputs))
         tester.eval()
-    testvectors = tester.test_vectors
 
     for cb in [genesis_cb, magma_cb]:
-        compile(f"test_cb/build/test_{cb.name}.cpp", cb, testvectors)
-        run_verilator_test(cb.name, f"test_{cb.name}", cb.name, ["-Wno-fatal"],
-                           build_dir="test_cb/build")
+        tester.circuit = cb
+        tester.compile_and_run("test_cb/build", target="verilator",
+                               flags=["-Wno-fatal"])

--- a/test_cb/test_cb_regression.py
+++ b/test_cb/test_cb_regression.py
@@ -10,7 +10,6 @@ from cb.cb_genesis2 import define_cb_wrapper
 
 import magma as m
 import fault
-from magma.testing.verilator import compile, run_verilator_test
 
 import pytest
 

--- a/test_global_controller/test_global_controller_genesis2.py
+++ b/test_global_controller/test_global_controller_genesis2.py
@@ -1,8 +1,6 @@
 from global_controller import global_controller_genesis2
 import glob
 import os
-import fault
-from magma.testing.verilator import compile, run_verilator_test
 
 
 def teardown_function():

--- a/test_mem/test_mem_genesis2.py
+++ b/test_mem/test_mem_genesis2.py
@@ -3,7 +3,6 @@ import glob
 import os
 import shutil
 import fault
-from magma.testing.verilator import compile, run_verilator_test
 from enum import Enum
 import random
 
@@ -176,6 +175,5 @@ def test_sram_basic():
     for addr, data in reference.items():
         tester.expect_read(addr, data)
 
-    compile(f"test_mem/build/test_{Mem.name}.cpp", Mem, tester.test_vectors)
-    run_verilator_test(Mem.name, f"test_{Mem.name}", Mem.name, ["-Wno-fatal"],
-                       build_dir="test_mem/build")
+    tester.compile_and_run(directory="test_mem/build", target="verilator",
+                           flags=["-Wno-fatal"])

--- a/test_simple_cb/test_simple_cb_regression.py
+++ b/test_simple_cb/test_simple_cb_regression.py
@@ -76,7 +76,7 @@ def test_regression(num_tracks):
             self.circuit = circuit
             self.genesis_to_magma_mapping = {
                 "clk": "CLK",
-                "reset": "RESET",
+                "reset": "ASYNCRESET",
                 "out": "O"
             }
 

--- a/test_simple_cb/test_simple_cb_regression.py
+++ b/test_simple_cb/test_simple_cb_regression.py
@@ -10,7 +10,6 @@ from simple_cb.simple_cb_genesis2 import define_simple_cb_wrapper
 
 import magma as m
 import fault
-from magma.testing.verilator import compile, run_verilator_test
 
 import pytest
 


### PR DESCRIPTION
This branch was stale, forgot to pull it in. It updates our tests to use fault's new `compile_and_run` interface. Also enables the test for the simple_cb by implementing a simple class to map the renamed ports.